### PR TITLE
Create headless Ceph svc and endpoints yaml

### DIFF
--- a/examples/kubernetes-cdxvirt/ceph-mon-ep.yaml
+++ b/examples/kubernetes-cdxvirt/ceph-mon-ep.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: ceph-mon
+  namespace: ceph
+  labels:
+    name: ceph-mon
+subsets:
+- addresses:
+  - ip: 192.168.33.80
+  - ip: 192.168.33.81
+  - ip: 192.168.33.82
+  ports:
+  - port: 6789
+    protocol: TCP

--- a/examples/kubernetes-cdxvirt/ceph-mon-svc.yaml
+++ b/examples/kubernetes-cdxvirt/ceph-mon-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceph-mon
+  namespace: ceph
+  labels:
+    name: ceph-mon
+spec:
+  clusterIP: None
+  ports:
+  - port: 6789
+    protocol: TCP


### PR DESCRIPTION
$ kubectl edit svc kube-dns --namespace=kube-system 
Edit as
spec:
  clusterIP: 10.0.0.10
  externalIPs:
  - 192.168.33.80

-----------------
edit /etc/resolv.conf of host as the following
search default.svc.cluster.local svc.cluster.local cluster.local
nameserver 192.168.33.80
options ndots:5